### PR TITLE
Use new rev ai url for GETs

### DIFF
--- a/revai.go
+++ b/revai.go
@@ -115,6 +115,7 @@ func (c *Client) newRequest(method string, path string, body interface{}) (*http
 		}
 	}()
 
+	u := c.BaseURL.ResolveReference(rel)
 	if method == http.MethodGet {
 		v, err := query.Values(body)
 		if err != nil {
@@ -122,9 +123,12 @@ func (c *Client) newRequest(method string, path string, body interface{}) (*http
 		}
 
 		rel.RawQuery = v.Encode()
-	}
 
-	u := c.BaseURL.ResolveReference(rel)
+		// TODO @Sylvie to revert. Temporary hack for rev ai dns switch.
+		// https://linear.app/descript/issue/BCK-2593/switch-rev-endpoint-to-prevent-dns-downtime.
+		newBaseUrl, _ := url.Parse("https://uw2.api.rev.ai")
+		u = newBaseUrl.ResolveReference(rel)
+	}
 
 	req, err := http.NewRequest(method, u.String(), pr)
 	if err != nil {


### PR DESCRIPTION
https://linear.app/descript/issue/BCK-2593/switch-rev-endpoint-to-prevent-dns-downtime

As discussed, modifies the rev ai wrapper to use the new URL for GET calls only