### PR TITLE
Revert "Use new rev ai url for GETs"

### DIFF
--- a/revai.go
+++ b/revai.go
@@ -115,7 +115,6 @@ func (c *Client) newRequest(method string, path string, body interface{}) (*http
 		}
 	}()
 
-	u := c.BaseURL.ResolveReference(rel)
 	if method == http.MethodGet {
 		v, err := query.Values(body)
 		if err != nil {
@@ -123,12 +122,9 @@ func (c *Client) newRequest(method string, path string, body interface{}) (*http
 		}
 
 		rel.RawQuery = v.Encode()
-
-		// TODO @Sylvie to revert. Temporary hack for rev ai dns switch.
-		// https://linear.app/descript/issue/BCK-2593/switch-rev-endpoint-to-prevent-dns-downtime.
-		newBaseUrl, _ := url.Parse("https://uw2.api.rev.ai")
-		u = newBaseUrl.ResolveReference(rel)
 	}
+
+	u := c.BaseURL.ResolveReference(rel)
 
 	req, err := http.NewRequest(method, u.String(), pr)
 	if err != nil {


### PR DESCRIPTION
Revert "Use new rev ai url for GETs"

This reverts commit 3e8b221588cc3c294c4a5eb5b0316838adf57b75.

Now that the dns switch is complete, the uw2 url is an alias of the
original one, so we can revert back to using the original url without any issues.