### PR TITLE
Add language return values to job json object

### DIFF
--- a/job.go
+++ b/job.go
@@ -18,18 +18,20 @@ type JobService service
 
 // Job represents a rev.ai async job.
 type Job struct {
-	ID              string    `json:"id"`
-	CreatedOn       time.Time `json:"created_on"`
-	Name            string    `json:"name"`
-	Status          string    `json:"status"`
-	Type            string    `json:"type"`
-	Metadata        string    `json:"metadata,omitempty"`
-	CompletedOn     time.Time `json:"completed_on,omitempty"`
-	CallbackURL     string    `json:"callback_url,omitempty"`
-	DurationSeconds float32   `json:"duration_seconds,omitempty"`
-	MediaURL        string    `json:"media_url,omitempty"`
-	Failure         string    `json:"failure,omitempty"`
-	FailureDetail   string    `json:"failure_detail,omitempty"`
+	ID               string    `json:"id"`
+	CreatedOn        time.Time `json:"created_on"`
+	Name             string    `json:"name"`
+	Status           string    `json:"status"`
+	Type             string    `json:"type"`
+	Metadata         string    `json:"metadata,omitempty"`
+	CompletedOn      time.Time `json:"completed_on,omitempty"`
+	CallbackURL      string    `json:"callback_url,omitempty"`
+	DurationSeconds  float32   `json:"duration_seconds,omitempty"`
+	MediaURL         string    `json:"media_url,omitempty"`
+	Failure          string    `json:"failure,omitempty"`
+	FailureDetail    string    `json:"failure_detail,omitempty"`
+	Language         string    `json:"language,omitempty"`
+	DetectedLanguage string    `json:"detected_language,omitempty"`
 }
 
 // NewFileJobParams specifies the parameters to the


### PR DESCRIPTION
The structure of the requests is not made clear in their API, but a simple experiment shows the expected input/output.

1. Create english transcription
2. Create auto transcription
3. Retrieve status of (1)
4. Retrieve status of (2)

```
curl -X POST "https://api.rev.ai/speechtotext/v1/jobs" -H "Authorization: Bearer $REV_ACCESS_TOKEN" -H "Content-Type: application/json" -d "{\"source_config\":{\"url\":\"https://storage.googleapis.com/pre-staging-255215-public-static/testing/numbers1to20-german.mp3\"}}"
{"id":"YOIZclyzBTFwFlP3","created_on":"2024-12-04T21:22:25.783Z","name":"numbers1to20-german.mp3","status":"in_progress","type":"async","strict_custom_vocabulary":false,"language":"en"}

$ curl -X POST "https://api.rev.ai/speechtotext/v1/jobs" -H "Authorization: Bearer $REV_ACCESS_TOKEN" -H "Content-Type: application/json" -d "{\"language\": \"auto\", \"source_config\":{\"url\":\"https://storage.googleapis.com/pre-staging-255215-public-static/testing/numbers1to20-german.mp3\"}}"
{"id":"nsk8XlE86ZVKxS9v","created_on":"2024-12-04T21:22:48.368Z","name":"numbers1to20-german.mp3","status":"in_progress","type":"async","strict_custom_vocabulary":false,"language":"auto"}

$ curl -X GET "https://api.rev.ai/speechtotext/v1/jobs/nsk8XlE86ZVKxS9v" -H "Authorization: Bearer $REV_ACCESS_TOKEN"
{"id":"nsk8XlE86ZVKxS9v","created_on":"2024-12-04T21:22:48.368Z","completed_on":"2024-12-04T21:23:10.466Z","name":"numbers1to20-german.mp3","status":"transcribed","duration_seconds":39.73,"type":"async","strict_custom_vocabulary":false,"language":"auto","detected_language":"de"}

$ curl -X GET "https://api.rev.ai/speechtotext/v1/jobs/YOIZclyzBTFwFlP3" -H "Authorization: Bearer $REV_ACCESS_TOKEN"
{"id":"YOIZclyzBTFwFlP3","created_on":"2024-12-04T21:22:25.783Z","completed_on":"2024-12-04T21:22:51.642Z","name":"numbers1to20-german.mp3","status":"transcribed","duration_seconds":39.73,"type":"async","strict_custom_vocabulary":false,"language":"en"}
```